### PR TITLE
remove duplicate link

### DIFF
--- a/src/index.scala
+++ b/src/index.scala
@@ -188,12 +188,6 @@ val header = div(
     ),
     " | ",
     a(
-      "Scala.js",
-      href := "https://scala-js.org",
-      basicLink
-    ),
-    " | ",
-    a(
       "Laminar",
       href := "https://laminar.dev",
       basicLink


### PR DESCRIPTION
Thanks for the project, always good to see dev tooling around Scalameta/Scalafix!

I tried to expose the Scalameta version as I was editing this file, but it looks like scalameta does not expose it via BuildInfo, so it's not a one-liner.

Ideally, the user could pick from a few minor Scalameta versions (I think that's what https://xuwei-k.github.io/scalameta-ast/ offers, but it seems some assets can't be loaded), but that's even more work :sweat_smile: 